### PR TITLE
Add prepare script so GitHub installs build dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "prepare": "npm run build",
     "test": "jest",
     "prepublishOnly": "npm run build"
   }


### PR DESCRIPTION
## Summary
- add `prepare` script (`npm run build`)
- ensures installs from `github:shakacode/pack-config-diff` build `dist` automatically

## Why
Shakapacker consumes this repo directly before npm publish; without `prepare`, `require("pack-config-diff")` fails because `dist/index.js` is missing in git installs.
