### PR TITLE
Add changelog-driven release infrastructure

### DIFF
--- a/.claude/commands/update-changelog.md
+++ b/.claude/commands/update-changelog.md
@@ -1,0 +1,170 @@
+# Update Changelog
+
+You are helping to add entries to the CHANGELOG.md file for the pack-config-diff project.
+
+## Arguments
+
+This command accepts an optional argument: `$ARGUMENTS`
+
+- **No argument** (`/update-changelog`): Add entries to `[Unreleased]` without stamping a version header. Use this during development.
+- **`release`** (`/update-changelog release`): Add entries and stamp a version header. Auto-compute the next version based on changes (breaking -> major, added features -> minor, fixes -> patch).
+- **Explicit version** (`/update-changelog 1.2.0`): Add entries and stamp the exact version provided. The version string must look like semver (with optional `-rc.N` or `-beta.N` suffix).
+
+## When to Use This
+
+**During development** — Add entries to `[Unreleased]` as PRs merge:
+
+- Run `/update-changelog` to find merged PRs missing from the changelog
+- Entries accumulate under `## [Unreleased]`
+
+**Before a release** — Stamp a version header and prepare for release:
+
+- Run `/update-changelog release` (or an explicit version) to add entries AND stamp the version header
+- After the PR merges, run `npm run release` — it reads the version from CHANGELOG.md
+
+## Critical Requirements
+
+1. **User-visible changes only**: Only add changelog entries for:
+   - New features
+   - Bug fixes
+   - Breaking changes
+   - Deprecations
+   - Performance improvements
+   - Security fixes
+   - Changes to public APIs or configuration options
+
+2. **Do NOT add entries for**:
+   - Linting fixes
+   - Code formatting
+   - Internal refactoring
+   - Test updates
+   - Documentation fixes (unless they fix incorrect docs about behavior)
+   - CI/CD changes
+
+## Formatting Requirements
+
+### Entry Format
+
+Each changelog entry MUST follow this exact format:
+
+```markdown
+- **Bold description of change**. [PR #N](https://github.com/shakacode/pack-config-diff/pull/N) by [username](https://github.com/username).
+```
+
+**Important formatting rules**:
+
+- Start with a dash and space: `- `
+- Use **bold** for the main description
+- End the bold description with a period before the link
+- Always link to the PR: `[PR #N](https://github.com/shakacode/pack-config-diff/pull/N)`
+- Always link to the author: `by [username](https://github.com/username)`
+- End with a period after the author link
+
+### Category Headings
+
+Entries should be organized under these headings (most critical first):
+
+1. `### Breaking Changes` — Breaking changes with migration notes
+2. `### Added` — New features
+3. `### Changed` — Changes to existing functionality
+4. `### Fixed` — Bug fixes
+5. `### Removed` — Removed features
+6. `### Security` — Security-related changes
+
+**Only include headings that have entries.**
+
+## Auto-Computing the Next Version
+
+When stamping a version header (`release` mode), compute the next version as follows:
+
+1. **Find the latest version tag**:
+
+   ```bash
+   git tag -l 'v*' --sort=-v:refname | head -5
+   ```
+
+2. **Determine bump type from changelog content**:
+   - If changes include `### Breaking Changes` -> **major** bump
+   - If changes include `### Added` -> **minor** bump
+   - If changes only include `### Fixed`, `### Security`, `### Changed`, `### Removed` -> **patch** bump
+
+3. **Compute the version**: Apply the bump to the latest tag (e.g., `v1.0.0` + minor -> `v1.1.0`)
+
+4. **Show the computed version to the user and ask for confirmation** before stamping. If the bump type is ambiguous, explain your reasoning and ask the user to confirm or override.
+
+## Version Links
+
+The CHANGELOG uses compare links at the bottom. The format is:
+
+```markdown
+[unreleased]: https://github.com/shakacode/pack-config-diff/compare/vX.Y.Z...HEAD
+[vX.Y.Z]: https://github.com/shakacode/pack-config-diff/compare/vPREV...vX.Y.Z
+```
+
+When stamping a version, update these links:
+
+1. Update `[unreleased]:` to compare from the new version to HEAD
+2. Add a new version link comparing the previous version to the new version
+
+## Process
+
+### Step 1: Fetch and read current state
+
+- **CRITICAL**: Run `git fetch origin main` to ensure you have the latest commits
+- After fetching, use `origin/main` for all comparisons, NOT local `main` branch
+- Read the current CHANGELOG.md to understand the existing structure
+
+### Step 2: Find commits since last tag
+
+1. Get the latest git tag: `git tag --sort=-v:refname | head -5`
+2. List commits since last tag: `git log --oneline LAST_TAG..origin/main`
+3. Extract PR numbers: `git log --oneline LAST_TAG..origin/main | grep -oE "#[0-9]+" | sort -u`
+4. For each PR number, check if it's already in CHANGELOG.md: `grep "PR #XXX" CHANGELOG.md`
+
+### Step 3: Add new entries
+
+For PRs not yet in the changelog:
+
+- Get PR details: `gh pr view NUMBER --json title,body,author --repo shakacode/pack-config-diff`
+- **Never ask the user for PR details** — get them from git history or the GitHub API
+- Validate that the change is user-visible (per the criteria above)
+- Add the entry to `### [Unreleased]` under the appropriate category heading
+
+### Step 4: Stamp version header (only when a version mode or explicit version is given)
+
+If the user passed `release` or an explicit version string:
+
+1. Compute or use the provided version
+2. Insert `## [vX.Y.Z] - YYYY-MM-DD` header immediately after `## [Unreleased]`
+3. Move all content from `[Unreleased]` to the new version section
+4. Leave `### [Unreleased]` empty
+5. Update the diff links at the bottom of the file
+
+### Step 5: Verify and finalize
+
+1. **Verify formatting**: Bold description with period, proper PR link, proper author link, file ends with newline
+2. **Verify version sections are in order** (Unreleased -> newest tag -> older tags)
+3. **Show the user** a summary of what was done
+4. If in `release` or explicit-version mode, **automatically commit, push, and open a PR**:
+   - Create a branch (e.g., `jg/changelog-v1.1.0`)
+   - Commit CHANGELOG.md
+   - Push and open a PR with the changelog diff
+   - Remind the user to run `npm run release` after merge
+
+## Examples
+
+### Good Entry
+
+```markdown
+- **Plugin-aware comparison mode** for class-instance configs. [PR #1](https://github.com/shakacode/pack-config-diff/pull/1) by [justin808](https://github.com/justin808).
+```
+
+### Entry with Sub-bullets
+
+```markdown
+- **Rich output format support**: Added multiple output formats for different use cases:
+  - `detailed` for human-readable console output
+  - `markdown` for PR-ready diff reports
+  - `json` and `yaml` for programmatic consumption
+  [PR #3](https://github.com/shakacode/pack-config-diff/pull/3) by [justin808](https://github.com/justin808).
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/). Please use the existing headings and styling as a guide.
+After a release, run `/update-changelog` in Claude Code to analyze commits, write entries, and create a PR.
+
+## [Unreleased]
+
+## [v1.0.0] - 2026-03-15
+
+### Added
+
+- **Semantic config diff engine** for webpack and rspack projects, with support for objects, arrays, functions, RegExp, Date, class instances, ignore keys/paths, max depth, and path separators.
+- **Plugin-aware comparison mode** for class-instance configs (`--plugin-aware`). [PR #1](https://github.com/shakacode/pack-config-diff/pull/1) by [justin808](https://github.com/justin808).
+- **Module rule matching by test pattern** to reduce reorder noise (`--match-rules-by-test`). [PR #2](https://github.com/shakacode/pack-config-diff/pull/2) by [justin808](https://github.com/justin808).
+- **Markdown output format** for PR-ready diff reports. [PR #3](https://github.com/shakacode/pack-config-diff/pull/3) by [justin808](https://github.com/justin808).
+- **CLI** with `--left`/`--right`, `--format`, `--output`, `--plugin-aware`, `--match-rules-by-test`, and other options.
+- **Programmatic API** via `DiffEngine` and `DiffFormatter` classes.
+- **Cross-platform path normalization** and base-path detection.
+- **Rich output formats**: detailed, summary, json, yaml, markdown.
+- **Contextual documentation mapping** for common webpack/rspack config keys.
+- **`prepare` script** for git installs so `dist/` builds automatically. [PR #5](https://github.com/shakacode/pack-config-diff/pull/5) by [justin808](https://github.com/justin808).
+
+[unreleased]: https://github.com/shakacode/pack-config-diff/compare/v1.0.0...HEAD
+[v1.0.0]: https://github.com/shakacode/pack-config-diff/releases/tag/v1.0.0

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,113 @@
+# Releasing pack-config-diff
+
+This project uses a changelog-driven release workflow. The target version is always read from `CHANGELOG.md` — there is no version argument. Update the changelog first, then run the release script.
+
+## Prerequisites
+
+1. **npm authentication**: `npm whoami` must succeed
+2. **GitHub CLI**: `gh auth status` must succeed with write access
+3. **Clean git on main**: `git status` must be clean, branch must be `main`
+
+## Release Process
+
+### 1. Update the Changelog
+
+Update `CHANGELOG.md` with the target version header and entries.
+
+**Option A — Use Claude Code (recommended):**
+
+Run `/update-changelog release` to:
+
+- Find merged PRs missing from the changelog
+- Add entries under appropriate category headings
+- Stamp the version header (e.g., `## [v1.1.0] - 2026-03-20`)
+- Commit, push, and open a PR
+
+Review and merge the PR.
+
+**Option B — Manual:**
+
+1. Move entries from `### [Unreleased]` to a new `## [vX.Y.Z] - YYYY-MM-DD` header
+2. Update the `[unreleased]:` compare link at the bottom
+3. Add a new version compare link
+4. Commit and push to `main`
+
+### 2. Run the Release Script
+
+```bash
+# Recommended: dry run first
+npm run release:dry-run
+
+# Actual release
+npm run release
+```
+
+The script will:
+
+1. Read the target version from the first `## [vX.Y.Z]` header in CHANGELOG.md
+2. Compare to `package.json` — exit if already at that version
+3. Run pre-flight checks (clean git, main branch, npm auth, gh auth, tag doesn't exist)
+4. Run `npm test` and `npm run build`
+5. Show a summary and ask for confirmation
+6. Run `npx release-it` to bump `package.json`, commit, tag, and publish to npm
+7. Create a GitHub release from the CHANGELOG section via `gh`
+
+### 3. Verify
+
+- npm: https://www.npmjs.com/package/pack-config-diff
+- GitHub releases: https://github.com/shakacode/pack-config-diff/releases
+
+## Pre-release Versions
+
+Use npm semver pre-release format in the CHANGELOG header:
+
+```markdown
+## [v2.0.0-rc.1] - 2026-04-01
+```
+
+The script auto-detects the pre-release suffix and publishes with `--npm.tag=next` instead of `latest`. Users install with:
+
+```bash
+npm install pack-config-diff@next
+```
+
+## What the Script Does
+
+`scripts/release.sh` performs these steps:
+
+1. Reads version from `CHANGELOG.md` (first `## [vX.Y.Z]` after `[Unreleased]`)
+2. Compares to `package.json` version — exits if no release needed
+3. Detects pre-release (version contains `-`) and sets npm dist-tag accordingly
+4. Pre-flight checks: clean git, main branch, no existing tag, npm/gh auth
+5. Runs `npm test && npm run build` (skippable with `--skip-tests`)
+6. Shows summary and prompts for interactive confirmation
+7. Runs `npx release-it <version>` with CLI flags (no config file, no devDependency)
+8. Creates GitHub release via `gh release create` with notes from CHANGELOG section
+
+## Troubleshooting
+
+**Version already exists on npm:**
+Choose a different version in CHANGELOG.md and re-run.
+
+**npm publish failed after tag was created:**
+Delete the tag (`git tag -d vX.Y.Z && git push origin :vX.Y.Z`), fix the issue, and re-run.
+
+**GitHub release failed after npm publish:**
+Run manually: `gh release create vX.Y.Z --title "vX.Y.Z" --notes "..."`
+
+**Manual release fallback:**
+
+```bash
+# Bump version
+npm version X.Y.Z --no-git-tag-version
+git add package.json package-lock.json
+git commit -m "Release vX.Y.Z"
+git tag vX.Y.Z
+git push && git push --tags
+
+# Publish
+npm publish
+
+# GitHub release
+gh release create vX.Y.Z --title "vX.Y.Z" --notes "Release notes here"
+```

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "build": "tsc",
     "prepare": "npm run build",
     "test": "jest",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "release": "bash scripts/release.sh",
+    "release:dry-run": "bash scripts/release.sh --dry-run"
   }
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+DRY_RUN=false
+SKIP_TESTS=false
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/release.sh [options]
+
+Changelog-driven release script for pack-config-diff.
+Reads the target version from CHANGELOG.md and publishes to npm.
+
+Options:
+  --dry-run       Run release-it in dry-run mode (no publish, no tag, no push)
+  --skip-tests    Skip test and build checks (not recommended)
+  -h, --help      Show this help message
+
+The release version is always read from CHANGELOG.md — there is no version argument.
+Update CHANGELOG.md first, then run this script.
+EOF
+}
+
+log_info()  { echo -e "${GREEN}[INFO]${NC} $*"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+confirm() {
+  local prompt="$1"
+  echo -en "${BOLD}${prompt} [y/N] ${NC}"
+  read -r answer </dev/tty
+  case "$answer" in
+    [yY]|[yY][eE][sS]) return 0 ;;
+    *) echo "Aborted."; exit 1 ;;
+  esac
+}
+
+# ── Parse arguments ──────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)    DRY_RUN=true; shift ;;
+    --skip-tests) SKIP_TESTS=true; shift ;;
+    -h|--help)    usage; exit 0 ;;
+    *) log_error "Unknown option: $1"; usage; exit 1 ;;
+  esac
+done
+
+# ── Read version from CHANGELOG.md ──────────────────────────────────────────
+
+parse_version_from_changelog() {
+  local header
+  header=$(grep -m1 -E '^## \[v[0-9]' CHANGELOG.md || true)
+
+  if [[ -z "$header" ]]; then
+    log_error "No version header found in CHANGELOG.md (expected: ## [vX.Y.Z] - YYYY-MM-DD)"
+    exit 1
+  fi
+
+  RELEASE_VERSION=$(echo "$header" | sed -E 's/^## \[v([^]]+)\].*/\1/')
+  RELEASE_DATE=$(echo "$header" | sed -E 's/.*\] - ([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1/')
+  log_info "CHANGELOG version: v${RELEASE_VERSION} (${RELEASE_DATE})"
+}
+
+# ── Read current version from package.json ───────────────────────────────────
+
+parse_current_version() {
+  CURRENT_VERSION=$(node -p "require('./package.json').version")
+  log_info "package.json version: ${CURRENT_VERSION}"
+}
+
+# ── Compare versions ─────────────────────────────────────────────────────────
+
+check_version_differs() {
+  if [[ "$RELEASE_VERSION" == "$CURRENT_VERSION" ]]; then
+    log_info "No release needed — CHANGELOG.md version (${RELEASE_VERSION}) matches package.json."
+    exit 0
+  fi
+}
+
+# ── Detect prerelease ────────────────────────────────────────────────────────
+
+detect_npm_tag() {
+  if [[ "$RELEASE_VERSION" == *-* ]]; then
+    NPM_TAG="next"
+    log_info "Prerelease detected — npm dist-tag: next"
+  else
+    NPM_TAG="latest"
+  fi
+}
+
+# ── Pre-flight checks ───────────────────────────────────────────────────────
+
+preflight_checks() {
+  echo ""
+  log_info "Running pre-flight checks..."
+
+  if ! git diff --quiet || ! git diff --cached --quiet; then
+    log_error "Git working tree must be clean. Commit or stash changes first."
+    exit 1
+  fi
+  echo "  ✓ Clean working tree"
+
+  local branch
+  branch=$(git branch --show-current)
+  if [[ "$branch" != "main" ]]; then
+    log_error "Releases must be run from main (current: ${branch})."
+    exit 1
+  fi
+  echo "  ✓ On main branch"
+
+  if git rev-parse "v${RELEASE_VERSION}" >/dev/null 2>&1; then
+    log_error "Git tag v${RELEASE_VERSION} already exists."
+    exit 1
+  fi
+  echo "  ✓ Tag v${RELEASE_VERSION} does not exist"
+
+  if git ls-remote --exit-code --tags origin "refs/tags/v${RELEASE_VERSION}" >/dev/null 2>&1; then
+    log_error "Git tag v${RELEASE_VERSION} already exists on origin."
+    exit 1
+  fi
+  echo "  ✓ Tag v${RELEASE_VERSION} does not exist on origin"
+
+  if ! npm whoami >/dev/null 2>&1; then
+    log_error "Not logged in to npm. Run 'npm login' first."
+    exit 1
+  fi
+  echo "  ✓ Logged in to npm as: $(npm whoami)"
+
+  if ! gh auth status >/dev/null 2>&1; then
+    log_error "Not authenticated with GitHub CLI. Run 'gh auth login' first."
+    exit 1
+  fi
+  echo "  ✓ GitHub CLI authenticated"
+}
+
+# ── Run tests ────────────────────────────────────────────────────────────────
+
+run_tests() {
+  if [[ "$SKIP_TESTS" == true ]]; then
+    log_warn "Skipping tests (--skip-tests)."
+    return
+  fi
+  echo ""
+  log_info "Running tests and build..."
+  npm test
+  npm run build
+  log_info "Tests and build passed."
+}
+
+# ── Show summary and confirm ─────────────────────────────────────────────────
+
+show_summary_and_confirm() {
+  echo ""
+  echo "════════════════════════════════════════════════════════════════"
+  echo -e "  ${BOLD}Release Summary${NC}"
+  echo "════════════════════════════════════════════════════════════════"
+  echo "  Current version:  ${CURRENT_VERSION}"
+  echo "  Release version:  ${RELEASE_VERSION}"
+  echo "  npm dist-tag:     ${NPM_TAG}"
+  echo "  Dry run:          ${DRY_RUN}"
+  echo "════════════════════════════════════════════════════════════════"
+  echo ""
+
+  if [[ "$DRY_RUN" == true ]]; then
+    log_info "DRY RUN — no changes will be made."
+  else
+    confirm "Proceed with release v${RELEASE_VERSION}?"
+  fi
+}
+
+# ── Run release-it ───────────────────────────────────────────────────────────
+
+do_release() {
+  echo ""
+  log_info "Running release-it..."
+
+  local -a args=(
+    "${RELEASE_VERSION}"
+    "--npm.publish"
+    "--npm.tag=${NPM_TAG}"
+    "--no-git.requireCleanWorkingDir"
+    "--no-github.release"
+    "--git.tagName=v\${version}"
+    "--git.commitMessage=Release v\${version}"
+    "--git.tagAnnotation=Release v\${version}"
+  )
+
+  if [[ "$DRY_RUN" == true ]]; then
+    args+=("--dry-run" "--verbose")
+  fi
+
+  echo "  npx release-it ${args[*]}"
+  npx release-it "${args[@]}"
+}
+
+# ── Extract changelog section ────────────────────────────────────────────────
+
+extract_changelog_section() {
+  # Extract text between ## [vVERSION] and the next ## [ header,
+  # stripping footer link references and trailing blank lines.
+  awk '
+    /^## \[v'"${RELEASE_VERSION}"'\]/ { found=1; next }
+    /^## \[/ { if (found) exit }
+    found && /^\[.+\]:/ { next }
+    found { print }
+  ' CHANGELOG.md | awk 'NF{p=1} p' | awk '{lines[NR]=$0} END{for(i=NR;i>0;i--) if(lines[i]!=""){last=i;break} for(i=1;i<=last;i++) print lines[i]}'
+}
+
+# ── Create GitHub release ────────────────────────────────────────────────────
+
+create_github_release() {
+  if [[ "$DRY_RUN" == true ]]; then
+    log_info "DRY RUN: Would create GitHub release v${RELEASE_VERSION}"
+    echo "  Release notes:"
+    extract_changelog_section | head -20
+    return
+  fi
+
+  echo ""
+  log_info "Creating GitHub release..."
+
+  local notes
+  notes=$(extract_changelog_section)
+
+  if [[ -z "$notes" ]]; then
+    log_warn "No changelog section found for v${RELEASE_VERSION}. Creating release without notes."
+    gh release create "v${RELEASE_VERSION}" --title "v${RELEASE_VERSION}" --notes ""
+  else
+    gh release create "v${RELEASE_VERSION}" --title "v${RELEASE_VERSION}" --notes "$notes"
+  fi
+
+  log_info "GitHub release created: v${RELEASE_VERSION}"
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+main() {
+  echo ""
+  echo -e "${BOLD}pack-config-diff release${NC}"
+  echo ""
+
+  parse_version_from_changelog
+  parse_current_version
+  check_version_differs
+  detect_npm_tag
+  preflight_checks
+  run_tests
+  show_summary_and_confirm
+  do_release
+  create_github_release
+
+  echo ""
+  echo "════════════════════════════════════════════════════════════════"
+  if [[ "$DRY_RUN" == true ]]; then
+    echo -e "  ${GREEN}${BOLD}DRY RUN COMPLETE${NC}"
+  else
+    echo -e "  ${GREEN}${BOLD}RELEASE COMPLETE: v${RELEASE_VERSION}${NC}"
+    echo ""
+    echo "  npm: https://www.npmjs.com/package/pack-config-diff"
+    echo "  GitHub: https://github.com/shakacode/pack-config-diff/releases"
+  fi
+  echo "════════════════════════════════════════════════════════════════"
+  echo ""
+}
+
+main


### PR DESCRIPTION
## Summary

Adds a complete release workflow modeled after shakacode/shakapacker's philosophy: manual, changelog-driven, no CI automation.

- **`CHANGELOG.md`** — Keep a Changelog format with v1.0.0 initial release entry
- **`scripts/release.sh`** — Interactive release script using `npx release-it` (no devDependency, no `.release-it.json` config file — all via CLI flags)
- **`docs/releasing.md`** — Step-by-step maintainer release guide
- **`.claude/commands/update-changelog.md`** — `/update-changelog` command for Claude Code changelog automation
- **`package.json`** — Added `release` and `release:dry-run` npm scripts

### Release flow

1. Update CHANGELOG.md with target version header (manually or via `/update-changelog release`)
2. Run `npm run release` (or `npm run release:dry-run` first)
3. Script reads version from CHANGELOG.md, runs tests/build, confirms interactively, publishes to npm via `npx release-it`, creates GitHub release via `gh`

### Key design decisions

- **No CI release workflow** — releases are manual from maintainer's machine
- **No release-it devDependency** — uses `npx` (always latest, no lock file bloat)
- **No `.release-it.json`** — all config via CLI flags, keeping repo clean
- **Interactive confirmation** — no `--ci` flag, requires explicit y/n
- **`gh` for GitHub releases** — not release-it's built-in GitHub support
- **Changelog-driven versioning** — no version argument; script always reads from CHANGELOG.md

## Test plan

- [x] `scripts/release.sh --help` shows usage
- [x] `npm run release:dry-run` correctly detects "no release needed" when versions match
- [x] Changelog section extraction correctly strips footer link references
- [ ] Full release flow with a version bump (manual test when ready)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new manual release script that publishes to npm and creates GitHub releases, so mistakes in version parsing/changelog formatting or local environment assumptions could impact release integrity.
> 
> **Overview**
> Adds a **changelog-driven release workflow**: introduces `CHANGELOG.md` (with `v1.0.0` baseline + compare links) and a new `scripts/release.sh` that reads the target version from the changelog, runs preflight checks/tests, publishes via `npx release-it`, and creates a GitHub release via `gh` (with `--dry-run` support).
> 
> Adds maintainer documentation in `docs/releasing.md`, adds npm scripts `release`/`release:dry-run`, and provides a Claude Code `/update-changelog` command spec to automate updating and stamping changelog entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6fa6b96a3d6dbab802a60c379328ea332501e29. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->