### PR TITLE
fix: allow same-version releases

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -51,6 +51,7 @@ The script will:
    - `package.json` already matches the release version: proceed if that version is still unpublished
    - `package.json` is behind the changelog version: let `release-it` update `package.json` and `package-lock.json`
    - `package.json` is ahead of the changelog version: stop with an error until the files agree
+   - when the version is already updated, the script passes the same-version flags to `release-it` so the first publish can still proceed
 3. Run pre-flight checks (clean git, main branch, tag doesn't exist, and auth checks for actual releases)
 4. Run `npm test` and `npm run build`
 5. Show a summary and ask for confirmation

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -350,7 +350,7 @@ do_release() {
   )
 
   if [[ "$ALLOW_SAME_VERSION_RELEASE" == true ]]; then
-    args+=("--npm.skipChecks" "--npm.ignoreVersion")
+    args+=("--npm.skipChecks" "--npm.ignoreVersion" "--npm.allowSameVersion")
   elif [[ "$DRY_RUN" == true && "$NPM_AUTHENTICATED" != true ]]; then
     args+=("--npm.skipChecks")
   fi


### PR DESCRIPTION
## Summary
- add `--npm.allowSameVersion` to the same-version release path in `scripts/release.sh`
- document that same-version first publishes are passed through to `release-it`

## Why
The script already recognized the `package.json already matches CHANGELOG.md` case, but live `npm run release` still failed because `release-it` invoked `npm version` without `--allow-same-version`.

## Validation
- `bash -n scripts/release.sh`
- `git diff --check`
- direct `release-it` dry-run confirmed `npm version 0.1.0 --no-git-tag-version --allow-same-version` and completed successfully

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release/publish script path; while small, an incorrect flag combination could cause failed releases or unintended npm versioning behavior.
> 
> **Overview**
> Enables same-version first-time publishes by passing `--npm.allowSameVersion` to `release-it` when the script detects `package.json` already matches the target `CHANGELOG.md` version.
> 
> Updates `docs/releasing.md` to document that the release script forwards same-version flags in this already-updated case so the initial publish can proceed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 525d8ec2cee4636a5917607b7f83d11a5ad37eea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release documentation to clarify behavior when package version matches changelog release version
* **Chores**
  * Enhanced release script to properly handle version matching scenarios during the publish flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->