### PR TITLE
Fix Claude OAuth token env for Actions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,6 +22,8 @@ jobs:
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "dependabot[bot]"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,8 @@ jobs:
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         with:
           github_token: ${{ github.token }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- pass `CLAUDE_CODE_OAUTH_TOKEN` through the Claude action step `env` as well as the existing `with:` input
- keep OAuth token wiring consistent for Claude review and `@claude` workflows

## Why
`anthropics/claude-code-action@v1` can resolve the OAuth input empty in this runner path unless the token is also available in the inherited step env. This matches the Hichee fix proven by shakacode/hichee#9633.

## Verification
- workflow-only YAML patch generated from the org Claude integration audit
